### PR TITLE
Health System logic

### DIFF
--- a/core/src/no/group15/playmagic/ecs/components/HealthComponent.kt
+++ b/core/src/no/group15/playmagic/ecs/components/HealthComponent.kt
@@ -1,7 +1,14 @@
 package no.group15.playmagic.ecs.components
 
 import com.badlogic.ashley.core.Component
+import com.badlogic.gdx.utils.Pool
 
-class HealthComponent : Component {
-	var points : Int = 100 // TODO chose a good default value?
+class HealthComponent: Component, Pool.Poolable {
+	var points: Int = 100 // TODO choose a good default value?
+	var maxPoints: Int = 100
+
+	override fun reset() {
+		points = 100
+		maxPoints = 100
+	}
 }

--- a/core/src/no/group15/playmagic/ecs/components/HealthComponent.kt
+++ b/core/src/no/group15/playmagic/ecs/components/HealthComponent.kt
@@ -1,0 +1,7 @@
+package no.group15.playmagic.ecs.components
+
+import com.badlogic.ashley.core.Component
+
+class HealthComponent : Component {
+	var points : Int = 100 // TODO chose a good default value?
+}

--- a/core/src/no/group15/playmagic/ecs/systems/HealthSystem.kt
+++ b/core/src/no/group15/playmagic/ecs/systems/HealthSystem.kt
@@ -1,0 +1,33 @@
+package no.group15.playmagic.ecs.systems
+
+import com.badlogic.ashley.core.EntitySystem
+import com.badlogic.ashley.signals.Listener
+import com.badlogic.ashley.signals.Signal
+import ktx.ashley.get
+import ktx.ashley.has
+import ktx.ashley.mapperFor
+import no.group15.playmagic.ecs.components.HealthComponent
+import no.group15.playmagic.events.ExplosionHitsPlayerEvent
+
+const val BOMB_EXPLOSION_DAMAGE = 10 //TODO chose a good value (and a good place in the source code?)
+
+class HealthSystem(
+	priority: Int
+) : EntitySystem(
+	priority
+), Listener<ExplosionHitsPlayerEvent> {
+
+	private val health = mapperFor<HealthComponent>()
+
+	override fun receive(signal: Signal<ExplosionHitsPlayerEvent>,
+						 event: ExplosionHitsPlayerEvent) {
+
+		assert( event.player.has(health) ) { "The entity hasn't a Health Component." }
+
+		// !! required because player[health] type is nullable
+		// ? gives error with -= operator
+		event.player[health]!!.points -= BOMB_EXPLOSION_DAMAGE
+
+	}
+
+}

--- a/core/src/no/group15/playmagic/events/ExplosionHitsPlayerEvent.kt
+++ b/core/src/no/group15/playmagic/events/ExplosionHitsPlayerEvent.kt
@@ -1,0 +1,7 @@
+package no.group15.playmagic.events
+
+import com.badlogic.ashley.core.Entity
+
+class ExplosionHitsPlayerEvent(
+	val player: Entity
+)


### PR DESCRIPTION
Hi,

I'm working on issue #6, this pull request is just to get some feedback on the logic.

I tried to implemented the logic in the simplest way, so I used the Signal/Listener API offered by Ashley. The Health System receive an ExplosionHitsPlayerEvent and it update the health. The event contains the player entity. Basically I delegated all the collision logic outside.

Other things to consider:
- [ ] health points default value
- [ ] bomb damage value and where to put it